### PR TITLE
Make go binary smaller

### DIFF
--- a/compile.sh
+++ b/compile.sh
@@ -5,7 +5,7 @@ ghc -O2 -split-objs hello.hs
 mv hello hello_hs
 
 # http://stackoverflow.com/a/21135705/492186
-go build -ldflags "-s" hello.go
+go build -ldflags "-s -w" hello.go
 mv hello hello_go
 
 ldc2 -Oz hello.d


### PR DESCRIPTION
Added the -w ldflag to strip debug info from binary.
$ go tool link
...
-s  disable symbol table
...
-w  disable DWARF generation
...