### PR TITLE
Use println function instead of fmt.Println

### DIFF
--- a/hello.go
+++ b/hello.go
@@ -1,5 +1,5 @@
 package main
  
-import "fmt"
- 
-func main() { fmt.Println("Hello world!") }
+func main() {
+	println("Hello world!")
+}


### PR DESCRIPTION
The funcionallity of fmt.Println() includes printing any type vs. println() only printing strings, much like the print functions from the other languages which are used. 
Which is just a unfair comparison especially when used for advertising the own language at https://nim-lang.org/features.html