### PR TITLE
Updated versions, added C binary

### DIFF
--- a/compile.sh
+++ b/compile.sh
@@ -26,3 +26,6 @@ mv hello hello_pas
 nasm -f elf64 hello.asm
 ld hello.o -o hello
 mv hello hello_asm
+
+v hello.v
+mv hello hello_v

--- a/compile.sh
+++ b/compile.sh
@@ -22,3 +22,7 @@ mv hello hello_c
 
 fpc hello.pas
 mv hello hello_pas
+
+nasm -f elf64 hello.asm
+ld hello.o -o hello
+mv hello hello_asm

--- a/compile.sh
+++ b/compile.sh
@@ -19,3 +19,6 @@ mv hello hello_crystal
 
 gcc -o hello hello.c
 mv hello hello_c
+
+fpc hello.pas
+mv hello hello_pas

--- a/hello.asm
+++ b/hello.asm
@@ -1,0 +1,15 @@
+section .data
+msg     db      'Hello world!', 0AH
+len     equ     $-msg
+ 
+section .text
+global  _start
+_start: mov     edx, len
+        mov     ecx, msg
+        mov     ebx, 1
+        mov     eax, 4
+        int     80h
+ 
+        mov     ebx, 0
+        mov     eax, 1
+        int     80h

--- a/hello.pas
+++ b/hello.pas
@@ -1,0 +1,4 @@
+program hello;
+begin
+ writeln('Hello world!');
+end.

--- a/hello.v
+++ b/hello.v
@@ -1,0 +1,3 @@
+fn main() {
+        println('Hello World!')
+}

--- a/readme.md
+++ b/readme.md
@@ -8,8 +8,8 @@ See ``compile.sh`` for the build flags used for each language.
 -rwxr-xr-x. 1 root root 1392640 Nov 22 14:26 hello_go       # go version go1.15.2 linux/amd64
 -rwxr-xr-x. 1 root root  919688 Nov 22 14:26 hello_hs       # The Glorious Glasgow Haskell Compilation System, version 8.8.4
 -rwxr-xr-x. 1 root root  471072 Nov 22 14:26 hello_crystal  # Crystal 0.35.1 [5999ae29b] (2020-06-19)
--rwxr-xr-x. 1 root root  409936 Nov 22 14:26 hello_nim      # Nim Compiler Version 1.0.4 [Linux: amd64]
 -rwxr-xr-x. 1 root root  352296 Nov 22 14:26 hello_rust     # rustc 1.47.0
+-rwxr-xr-x. 1 root root   88840 Nov 22 14:26 hello_nim      # Nim Compiler Version 1.4.0 [Linux: amd64]
 -rwxr-xr-x. 1 root root   22144 Nov 22 14:26 hello_d        # LDC - the LLVM D compiler (1.23.0)
 -rwxr-xr-x. 1 root root   20592 Nov 22 14:26 hello_c        # gcc (GCC) 10.2.1 20201016 (Red Hat 10.2.1-6)
 ```
@@ -20,7 +20,7 @@ Stripped versions (GNU strip version 2.35-14.fc33):
 -rwxr-xr-x. 1 root root  716296 Nov 22 14:30 hello_hs
 -rwxr-xr-x. 1 root root  405800 Nov 22 14:30 hello_crystal
 -rwxr-xr-x. 1 root root  289184 Nov 22 14:30 hello_rust
--rwxr-xr-x. 1 root root   47400 Nov 22 14:30 hello_nim
+-rwxr-xr-x. 1 root root   72544 Nov 22 14:30 hello_nim
 -rwxr-xr-x. 1 root root   15544 Nov 22 14:30 hello_d
 -rwxr-xr-x. 1 root root   15016 Nov 22 14:30 hello_c
 ```

--- a/readme.md
+++ b/readme.md
@@ -8,7 +8,7 @@ See ``compile.sh`` for the build flags used for each language.
 1392640 hello_go       # go version go1.15.2 linux/amd64
  919688 hello_hs       # The Glorious Glasgow Haskell Compilation System, version 8.8.4
  471072 hello_crystal  # Crystal 0.35.1 [5999ae29b] (2020-06-19)
- 352296 hello_rust     # rustc 1.47.0
+ 348608 hello_rust     # rustc 1.49.0
  190864 hello_pas      # Free Pascal Compiler version 3.2.0 [2020/07/27] for x86_64
   88840 hello_nim      # Nim Compiler Version 1.4.0 [Linux: amd64]
   22144 hello_d        # LDC - the LLVM D compiler (1.23.0)
@@ -20,7 +20,7 @@ Stripped versions (GNU strip version 2.35-14.fc33):
 1391832 hello_go
  716296 hello_hs
  405800 hello_crystal
- 289184 hello_rust
+ 285136 hello_rust
  190864 hello_pas
   72544 hello_nim
   15544 hello_d

--- a/readme.md
+++ b/readme.md
@@ -5,18 +5,20 @@ See ``compile.sh`` for the build flags used for each language.
 **Results:**
 
 ```
--rwxr-xr-x. 1 root root 1392640 Nov 22 14:26 hello_go    # go version go1.15.2 linux/amd64
--rwxr-xr-x. 1 root root  919688 Nov 22 14:26 hello_hs    # The Glorious Glasgow Haskell Compilation System, version 8.8.4
--rwxr-xr-x. 1 root root  409936 Nov 22 14:26 hello_nim   # Nim Compiler Version 1.0.4 [Linux: amd64]
--rwxr-xr-x. 1 root root  352296 Nov 22 14:26 hello_rust  # rustc 1.47.0
--rwxr-xr-x. 1 root root   22144 Nov 22 14:26 hello_d     # LDC - the LLVM D compiler (1.23.0)
--rwxr-xr-x. 1 root root   20592 Nov 22 14:26 hello_c     # gcc (GCC) 10.2.1 20201016 (Red Hat 10.2.1-6)
+-rwxr-xr-x. 1 root root 1392640 Nov 22 14:26 hello_go       # go version go1.15.2 linux/amd64
+-rwxr-xr-x. 1 root root  919688 Nov 22 14:26 hello_hs       # The Glorious Glasgow Haskell Compilation System, version 8.8.4
+-rwxr-xr-x. 1 root root  471072 Nov 22 14:26 hello_crystal  # Crystal 0.35.1 [5999ae29b] (2020-06-19)
+-rwxr-xr-x. 1 root root  409936 Nov 22 14:26 hello_nim      # Nim Compiler Version 1.0.4 [Linux: amd64]
+-rwxr-xr-x. 1 root root  352296 Nov 22 14:26 hello_rust     # rustc 1.47.0
+-rwxr-xr-x. 1 root root   22144 Nov 22 14:26 hello_d        # LDC - the LLVM D compiler (1.23.0)
+-rwxr-xr-x. 1 root root   20592 Nov 22 14:26 hello_c        # gcc (GCC) 10.2.1 20201016 (Red Hat 10.2.1-6)
 ```
 
 Stripped versions (GNU strip version 2.35-14.fc33):
 ```
 -rwxr-xr-x. 1 root root 1391832 Nov 22 14:30 hello_go
 -rwxr-xr-x. 1 root root  716296 Nov 22 14:30 hello_hs
+-rwxr-xr-x. 1 root root  405800 Nov 22 14:30 hello_crystal
 -rwxr-xr-x. 1 root root  289184 Nov 22 14:30 hello_rust
 -rwxr-xr-x. 1 root root   47400 Nov 22 14:30 hello_nim
 -rwxr-xr-x. 1 root root   15544 Nov 22 14:30 hello_d

--- a/readme.md
+++ b/readme.md
@@ -10,7 +10,7 @@ See ``compile.sh`` for the build flags used for each language.
  471072 hello_crystal  # Crystal 0.35.1 [5999ae29b] (2020-06-19)
  348608 hello_rust     # rustc 1.49.0
  190864 hello_pas      # Free Pascal Compiler version 3.2.0 [2020/07/27] for x86_64
-  88840 hello_nim      # Nim Compiler Version 1.4.0 [Linux: amd64]
+  88912 hello_nim      # Nim Compiler Version 1.4.2 [Linux: amd64]
   22144 hello_d        # LDC - the LLVM D compiler (1.23.0)
   20592 hello_c        # gcc (GCC) 10.2.1 20201016 (Red Hat 10.2.1-6)
 ```
@@ -22,7 +22,7 @@ Stripped versions (GNU strip version 2.35-14.fc33):
  405800 hello_crystal
  285136 hello_rust
  190864 hello_pas
-  72544 hello_nim
+  72592 hello_nim
   15544 hello_d
   15016 hello_c
 ```

--- a/readme.md
+++ b/readme.md
@@ -5,7 +5,7 @@ See ``compile.sh`` for the build flags used for each language.
 **Results:**
 
 ```
-1392640 hello_go       # go version go1.15.2 linux/amd64
+1388544 hello_go       # go version go1.15.6 linux/amd64
  919688 hello_hs       # The Glorious Glasgow Haskell Compilation System, version 8.8.4
  471072 hello_crystal  # Crystal 0.35.1 [5999ae29b] (2020-06-19)
  348608 hello_rust     # rustc 1.49.0
@@ -17,7 +17,7 @@ See ``compile.sh`` for the build flags used for each language.
 
 Stripped versions (GNU strip version 2.35-14.fc33):
 ```
-1391832 hello_go
+1387768 hello_go
  716296 hello_hs
  405800 hello_crystal
  285136 hello_rust

--- a/readme.md
+++ b/readme.md
@@ -5,12 +5,22 @@ See ``compile.sh`` for the build flags used for each language.
 **Results:**
 
 ```
--rwxr-xr-x   1 dom  staff    41184 14 Apr 16:29 hello_nim
--rwxr-xr-x   1 dom  staff   176912  7 Aug 13:10 hello_crystal
--rwxr-xr-x   1 dom  staff   331708 14 Apr 16:29 hello_rust
--rwxr-xr-x   1 dom  staff   974492 14 Apr 16:29 hello_d
--rwxr-xr-x   1 dom  staff  1382368 14 Apr 16:29 hello_hs
--rwxr-xr-x   1 dom  staff  1628192 14 Apr 16:29 hello_go
+-rwxr-xr-x. 1 root root 1392640 Nov 22 14:26 hello_go    # go version go1.15.2 linux/amd64
+-rwxr-xr-x. 1 root root  919688 Nov 22 14:26 hello_hs    # The Glorious Glasgow Haskell Compilation System, version 8.8.4
+-rwxr-xr-x. 1 root root  409936 Nov 22 14:26 hello_nim   # Nim Compiler Version 1.0.4 [Linux: amd64]
+-rwxr-xr-x. 1 root root  352296 Nov 22 14:26 hello_rust  # rustc 1.47.0
+-rwxr-xr-x. 1 root root   22144 Nov 22 14:26 hello_d     # LDC - the LLVM D compiler (1.23.0)
+-rwxr-xr-x. 1 root root   20592 Nov 22 14:26 hello_c     # gcc (GCC) 10.2.1 20201016 (Red Hat 10.2.1-6)
+```
+
+Stripped versions (GNU strip version 2.35-14.fc33):
+```
+-rwxr-xr-x. 1 root root 1391832 Nov 22 14:30 hello_go
+-rwxr-xr-x. 1 root root  716296 Nov 22 14:30 hello_hs
+-rwxr-xr-x. 1 root root  289184 Nov 22 14:30 hello_rust
+-rwxr-xr-x. 1 root root   47400 Nov 22 14:30 hello_nim
+-rwxr-xr-x. 1 root root   15544 Nov 22 14:30 hello_d
+-rwxr-xr-x. 1 root root   15016 Nov 22 14:30 hello_c
 ```
 
 **Criteria:** To avoid incessant "benchmark over-fitting" the code used for this benchmark is always the one readily available at Rosetta Code (http://rosettacode.org/wiki/Hello_world/Text). This means that I will not remove the "fmt" import from the [Go example](http://rosettacode.org/mw/index.php?title=Hello_world/Text&oldid=256503#Go). This also applies to compile flags to a certain extent. You can get very far [if you go down the rabbit hole](https://hookrace.net/blog/nim-binary-size/), so we need to stop somewhere, a good place to stop is "what are the typical flags an application is compiled under?".

--- a/readme.md
+++ b/readme.md
@@ -5,24 +5,26 @@ See ``compile.sh`` for the build flags used for each language.
 **Results:**
 
 ```
--rwxr-xr-x. 1 root root 1392640 Nov 22 14:26 hello_go       # go version go1.15.2 linux/amd64
--rwxr-xr-x. 1 root root  919688 Nov 22 14:26 hello_hs       # The Glorious Glasgow Haskell Compilation System, version 8.8.4
--rwxr-xr-x. 1 root root  471072 Nov 22 14:26 hello_crystal  # Crystal 0.35.1 [5999ae29b] (2020-06-19)
--rwxr-xr-x. 1 root root  352296 Nov 22 14:26 hello_rust     # rustc 1.47.0
--rwxr-xr-x. 1 root root   88840 Nov 22 14:26 hello_nim      # Nim Compiler Version 1.4.0 [Linux: amd64]
--rwxr-xr-x. 1 root root   22144 Nov 22 14:26 hello_d        # LDC - the LLVM D compiler (1.23.0)
--rwxr-xr-x. 1 root root   20592 Nov 22 14:26 hello_c        # gcc (GCC) 10.2.1 20201016 (Red Hat 10.2.1-6)
+1392640 hello_go       # go version go1.15.2 linux/amd64
+ 919688 hello_hs       # The Glorious Glasgow Haskell Compilation System, version 8.8.4
+ 471072 hello_crystal  # Crystal 0.35.1 [5999ae29b] (2020-06-19)
+ 352296 hello_rust     # rustc 1.47.0
+ 190864 hello_pas      # Free Pascal Compiler version 3.2.0 [2020/07/27] for x86_64
+  88840 hello_nim      # Nim Compiler Version 1.4.0 [Linux: amd64]
+  22144 hello_d        # LDC - the LLVM D compiler (1.23.0)
+  20592 hello_c        # gcc (GCC) 10.2.1 20201016 (Red Hat 10.2.1-6)
 ```
 
 Stripped versions (GNU strip version 2.35-14.fc33):
 ```
--rwxr-xr-x. 1 root root 1391832 Nov 22 14:30 hello_go
--rwxr-xr-x. 1 root root  716296 Nov 22 14:30 hello_hs
--rwxr-xr-x. 1 root root  405800 Nov 22 14:30 hello_crystal
--rwxr-xr-x. 1 root root  289184 Nov 22 14:30 hello_rust
--rwxr-xr-x. 1 root root   72544 Nov 22 14:30 hello_nim
--rwxr-xr-x. 1 root root   15544 Nov 22 14:30 hello_d
--rwxr-xr-x. 1 root root   15016 Nov 22 14:30 hello_c
+1391832 hello_go
+ 716296 hello_hs
+ 405800 hello_crystal
+ 289184 hello_rust
+ 190864 hello_pas
+  72544 hello_nim
+  15544 hello_d
+  15016 hello_c
 ```
 
 **Criteria:** To avoid incessant "benchmark over-fitting" the code used for this benchmark is always the one readily available at Rosetta Code (http://rosettacode.org/wiki/Hello_world/Text). This means that I will not remove the "fmt" import from the [Go example](http://rosettacode.org/mw/index.php?title=Hello_world/Text&oldid=256503#Go). This also applies to compile flags to a certain extent. You can get very far [if you go down the rabbit hole](https://hookrace.net/blog/nim-binary-size/), so we need to stop somewhere, a good place to stop is "what are the typical flags an application is compiled under?".

--- a/readme.md
+++ b/readme.md
@@ -13,6 +13,7 @@ See ``compile.sh`` for the build flags used for each language.
   88912 hello_nim      # Nim Compiler Version 1.4.2 [Linux: amd64]
   22144 hello_d        # LDC - the LLVM D compiler (1.23.0)
   20592 hello_c        # gcc (GCC) 10.2.1 20201016 (Red Hat 10.2.1-6)
+   8920 hello_asm      # NASM version 2.15.03 compiled on Jul 28 2020
 ```
 
 Stripped versions (GNU strip version 2.35-14.fc33):
@@ -25,6 +26,7 @@ Stripped versions (GNU strip version 2.35-14.fc33):
   72592 hello_nim
   15544 hello_d
   15016 hello_c
+   8488 hello_asm
 ```
 
 **Criteria:** To avoid incessant "benchmark over-fitting" the code used for this benchmark is always the one readily available at Rosetta Code (http://rosettacode.org/wiki/Hello_world/Text). This means that I will not remove the "fmt" import from the [Go example](http://rosettacode.org/mw/index.php?title=Hello_world/Text&oldid=256503#Go). This also applies to compile flags to a certain extent. You can get very far [if you go down the rabbit hole](https://hookrace.net/blog/nim-binary-size/), so we need to stop somewhere, a good place to stop is "what are the typical flags an application is compiled under?".

--- a/readme.md
+++ b/readme.md
@@ -8,6 +8,7 @@ See ``compile.sh`` for the build flags used for each language.
 1388544 hello_go       # go version go1.15.6 linux/amd64
  919688 hello_hs       # The Glorious Glasgow Haskell Compilation System, version 8.8.4
  471072 hello_crystal  # Crystal 0.35.1 [5999ae29b] (2020-06-19)
+ 462900 hello_v        # V 0.2 30c0659
  348608 hello_rust     # rustc 1.49.0
  190864 hello_pas      # Free Pascal Compiler version 3.2.0 [2020/07/27] for x86_64
   88912 hello_nim      # Nim Compiler Version 1.4.2 [Linux: amd64]
@@ -20,6 +21,7 @@ Stripped versions (GNU strip version 2.35-14.fc33):
 ```
 1387768 hello_go
  716296 hello_hs
+ 419056 hello_v
  405800 hello_crystal
  285136 hello_rust
  190864 hello_pas


### PR DESCRIPTION
Added C binary
Specified versions of compiles
Added test with stripped binaries

Everything, except of crystal, was tested on Fedora 33. Crystal was on Kali Linux.
